### PR TITLE
Using .npmrc file instead of env for package publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,10 @@ jobs:
       - name: Build library
         run: npm run build
 
+      - name: Authenticate in npm
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+        env: 
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish to npm registry
         run: npm publish
-        env:
-          # https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#set-the-token-as-an-environment-variable-on-the-cicd-server
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
For some reason action fails https://github.com/lidofinance/evm-script-decoder/actions/runs/3273228620/jobs/5385173701 even thought it's [officially documented](https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#set-the-token-as-an-environment-variable-on-the-cicd-server) way to share NPM_TOKEN.

Trying second [documented](https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#create-and-check-in-a-project-specific-npmrc-file) approach.