### PR TITLE
Added public publish parameter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,4 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm registry
-        run: npm publish
+        run: npm publish --access public


### PR DESCRIPTION
Forgot that scoped packages are published as private by default.